### PR TITLE
Show error message if Database.open() has been failed, minor bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ You can still use these if you cannot use async iterables. If you happen to have
 ```js
 let result = applesRepo.all();
 for (let item = await result.next(); !item.done; item = await result.next()) {
-    eatApple(apple);
+    eatApple(item.value);
 }
 burp();
 ```

--- a/src/database.ts
+++ b/src/database.ts
@@ -141,7 +141,7 @@ export class Database {
 		// Ready promise
 		
 		let resolveReady : (db : Database) => void;
-		var rejectReady : (err? : any) => void;
+		var rejectReady : (err : any) => void;
 		
 		var ready = new Promise<Database>(function(resolve, reject) {
 			resolveReady = resolve;
@@ -158,7 +158,7 @@ export class Database {
 
 		// these two event handlers act on the database being opened successfully, or not
 		DBOpenRequest.onerror = function (event) {
-			rejectReady();
+			rejectReady(DBOpenRequest.error);
 		};
 
 		DBOpenRequest.onsuccess = function (event) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { idbRequestToIterable } from './utils/idb/request-to-iterable';
 
 export class Index<TModel, TIndex> {
     constructor(repository : Repository<TModel>, name : string) {
+        this._repository = repository;
         this._name = name;
     }
 


### PR DESCRIPTION
Just some minor bug fixes.

I'm showing exact error message to make it easier for developer to understand what happened:
```javascript
rejectReady(DBOpenRequest.error);
```
I wanted to use `event.target.error` here, because I prefer not to use closured variables, but it seems it is not in **lib.dom.d.ts**, so I use `DBOpenRequest.error` like in MDN.

I've also found another bug that is `annotateFn()` doesn't work for `es6` and `es2017` targets, because class methods doesn't have `function` keyword and therefore the regular expression FN_ARGS fails to find matches. It fails even when annotating internal functions like `hydrateItem()` of `Repository` class, this is easy to reproduce by calling `.index('someindex').cursor()`. As I know Angular 2+ and TypeORM are using es2016 decorators (annotations) to deal with this issue.